### PR TITLE
Add list_container_images()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-gitlab>=5.0.0


### PR DESCRIPTION
This pulls down the list of images from our container registry to see if our tag already exists.  If so, skip the build.

We'll have to `pip install -r requirements.txt`.
