### PR TITLE
Pin SuperLU to v5

### DIFF
--- a/dockerfiles/cuda-gnu-openmpi/Dockerfile
+++ b/dockerfiles/cuda-gnu-openmpi/Dockerfile
@@ -66,7 +66,7 @@ spack:\n\
     - parallel-netcdf\n\
     - parmetis\n\
     - superlu-dist\n\
-    - superlu\n\
+    - superlu@5\n\
     - zlib\n\
     - openmpi${mpi_version}+cuda\n\
     - matio\n\

--- a/dockerfiles/gnu-openmpi/Dockerfile
+++ b/dockerfiles/gnu-openmpi/Dockerfile
@@ -58,7 +58,7 @@ spack:\n\
     - parallel-netcdf\n\
     - parmetis\n\
     - superlu-dist\n\
-    - superlu\n\
+    - superlu@5\n\
     - zlib\n\
     - openmpi${mpi_version}\n\
     - matio\n\

--- a/dockerfiles/gnu-serial/Dockerfile
+++ b/dockerfiles/gnu-serial/Dockerfile
@@ -53,7 +53,7 @@ spack:\n\
     - hdf5 +hl~mpi\n\
     - metis\n\
     - netcdf-c\n\
-    - superlu\n\
+    - superlu@5\n\
     - zlib\n\
     - matio\n\
     - python\n\


### PR DESCRIPTION
v6 and above do not currently work without changes to how SuperLU gets found/registered by Trilinos' build system, so table that work for a future day.

I tested this with the GCC serial container and it restored the working build.