### PR TITLE
Workflow for generating images

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,132 @@
+name: Container
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # cancel-in-progress: true
+
+env:
+    IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+    REGISTRY_USER: ${{ github.actor }}
+    REGISTRY_PASSWORD: ${{ github.token }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  container:
+    strategy:
+      matrix:
+        include:
+
+          - image_name: ubi8-gcc-12.1.0-openmpi-4.1.6
+            dockerfile: gnu-openmpi
+            build-args: |-
+              compiler_version=@12.1.0
+              mpi_version=@4.1.6
+            production: false
+
+          - image_name: ubi8-gcc-10.3.0-openmpi-4.1.6
+            dockerfile: gnu-openmpi
+            build-args: |-
+              compiler_version=@10.3.0"
+              mpi_version=@4.1.6
+            production: true
+
+          - image_name: ubi8-cuda-11.4.2-gcc-10.3.0-openmpi-4.1.6
+            dockerfile: cuda-gnu-openmpi
+            build-args: |-
+              compiler_version=@10.3.0"
+              mpi_version=@4.1.6
+              cuda_version=@11.4.2
+            production: true
+
+          - image_name: ubi8-cuda-12.4.1-gcc-10.3.0-openmpi-4.1.6
+            dockerfile: cuda-gnu-openmpi
+            build-args: |-
+              compiler_version=@10.3.0"
+              mpi_version=@4.1.6
+              cuda_version=@12.4.1
+            production: false
+
+          - image_name: ubi8-gcc-8.3.0-serial
+            dockerfile: gnu-serial
+            build-args: |-
+              compiler_version=@8.3.0
+            production: true
+
+          - image_name: ubi8-python-3.9
+            dockerfile: python
+            production: true
+
+          - image_name: ubi8-intel-intelmpi
+            dockerfile: intel-intelmpi
+            production: true
+
+    name: ${{ matrix.image_name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 1440
+
+    steps:
+    - name: Check out
+      if: always()
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      with:
+        fetch-depth: 0
+
+    - name: Generate tag (PR)
+      if: github.event_name == 'pull_request' && (github.actor != 'dependabot[bot]')
+      run: |
+        echo "tag=pr-${{ github.event.number }}" >> $GITHUB_ENV
+        if [[ "${{ matrix.production }}" = "true" ]] ; then
+           echo "readiness=production" >> $GITHUB_ENV
+        else
+           echo "readiness=experimental" >> $GITHUB_ENV
+        fi
+
+    - name: Generate tag (No PR)
+      if: (github.event_name != 'pull_request')
+      run: |
+        echo "tag=`git --no-pager log -1 --format=%cd --date=format:%Y%m%d -- .`" >> $GITHUB_ENV
+        if [[ "${{ matrix.production }}" = "true" ]] ; then
+           echo "readiness=production" >> $GITHUB_ENV
+        else
+           echo "readiness=experimental" >> $GITHUB_ENV
+        fi
+
+    - name: Build Image
+      id: build_image
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
+      with:
+        image: ${{ env.IMAGE_REGISTRY }}/containers/production/${{ matrix.image_name }}
+        tags: ${{ env.tag }}
+        containerfiles: dockerfiles/${{ matrix.dockerfile }}/Dockerfile
+        build-args: |-
+          ${{ matrix.build-args }}
+          AT2_image=${{ env.IMAGE_REGISTRY }}/${{ env.readiness }}/${{ matrix.image_name }}:${{ env.tag }}
+          AT2_image_fullpath=${{ matrix.image_name }}
+
+    - name: Push To GHCR
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+      id: push-pr
+      with:
+        image: ${{ steps.build_image.outputs.image }}
+        tags: ${{ env.tag }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ env.REGISTRY_PASSWORD }}
+        extra-args: |
+          --disable-content-trust
+
+    - name: Echo outputs
+      if: github.event_name == 'push'
+      run: |
+        echo "${{ toJSON(steps.push.outputs) }}"


### PR DESCRIPTION
Using a workflow from another repo as base, I threw together a CI action to generate and upload images.
Using Github's runners the action ran out of memory, so this would have to use SNL hosted runners.

If this isn't what you envisioned feel free to disregard.