### PR TITLE
Include copy of the Dockerfile inside the image containing the arg values used during building

### DIFF
--- a/dockerfiles/cuda-gnu-openmpi/Dockerfile
+++ b/dockerfiles/cuda-gnu-openmpi/Dockerfile
@@ -1,3 +1,10 @@
+# Default build argument values.
+# These must be redeclared after the FROM to allow for passed
+# build-args to override the default values.
+ARG compiler_version=
+ARG mpi_version=
+ARG cuda_version=
+
 FROM registry.access.redhat.com/ubi8:latest
 
 # Disable all host repositories so that we're only using things from UBI
@@ -19,7 +26,7 @@ RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/sha
 RUN bash -l -c "spack config add config:build_jobs:64"
 RUN bash -l -c "spack bootstrap now"
 
-ARG compiler_version=
+ARG compiler_version
 
 RUN bash -l -c "spack compiler find"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64 || true"
@@ -31,8 +38,8 @@ RUN bash -l -c "spack bootstrap now"
 RUN bash -l -c "echo \"export MODULEPATH=/home/runner/spack/share/spack/modules/linux-\\\$(spack arch --operating-system)-x86_64\" >> /home/runner/.bashrc"
 RUN bash -l -c "module load gcc && spack compiler find"
 
-ARG mpi_version=
-ARG cuda_version=
+ARG mpi_version
+ARG cuda_version
 
 RUN mkdir /home/runner/environment
 # Consider using here-documents once we get to Buildah 1.33.0+
@@ -158,10 +165,10 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 CMD [ "/bin/bash" ]
 
 # Image basename (useful for describing image characteristics, e.g. toolchain)
-ARG AT2_image
+ARG AT2_image=
 ENV AT2_IMAGE=${AT2_image}
 # Image path as pushed (useful for referencing where to pull the image)
-ARG AT2_image_fullpath
+ARG AT2_image_fullpath=
 ENV AT2_IMAGE_FULLPATH=${AT2_image_fullpath}
 
 RUN bash -l -c "spack module tcl refresh -y %gcc${compiler_version}"
@@ -206,6 +213,16 @@ else\n\
   export CCACHE_DIR=$HOME/ccache-dir\n\
   mkdir -p \$CCACHE_DIR\n\
 fi" >> /home/runner/.bashrc
+
+# Setup artifact Dockerfile in image
+RUN mkdir /home/runner/artifacts
+COPY Dockerfile /home/runner/artifacts/Dockerfile
+# Set artifact Dockerfile default arguments as the used build-arguments
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG cuda_version=\).*/\1${cuda_version}/" /home/runner/artifacts/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc

--- a/dockerfiles/cuda-gnu-openmpi/Dockerfile
+++ b/dockerfiles/cuda-gnu-openmpi/Dockerfile
@@ -1,10 +1,3 @@
-# Default build argument values.
-# These must be redeclared after the FROM to allow for passed
-# build-args to override the default values.
-ARG compiler_version=
-ARG mpi_version=
-ARG cuda_version=
-
 FROM registry.access.redhat.com/ubi8:latest
 
 # Disable all host repositories so that we're only using things from UBI
@@ -26,7 +19,7 @@ RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/sha
 RUN bash -l -c "spack config add config:build_jobs:64"
 RUN bash -l -c "spack bootstrap now"
 
-ARG compiler_version
+ARG compiler_version=
 
 RUN bash -l -c "spack compiler find"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64 || true"
@@ -38,8 +31,8 @@ RUN bash -l -c "spack bootstrap now"
 RUN bash -l -c "echo \"export MODULEPATH=/home/runner/spack/share/spack/modules/linux-\\\$(spack arch --operating-system)-x86_64\" >> /home/runner/.bashrc"
 RUN bash -l -c "module load gcc && spack compiler find"
 
-ARG mpi_version
-ARG cuda_version
+ARG mpi_version=
+ARG cuda_version=
 
 RUN mkdir /home/runner/environment
 # Consider using here-documents once we get to Buildah 1.33.0+

--- a/dockerfiles/gnu-openmpi/Dockerfile
+++ b/dockerfiles/gnu-openmpi/Dockerfile
@@ -1,9 +1,3 @@
-# Default build argument values.
-# These must be redeclared after the FROM to allow for passed
-# build-args to override the default values.
-ARG compiler_version=
-ARG mpi_version=
-
 FROM registry.access.redhat.com/ubi8:latest
 
 # Disable all host repositories so that we're only using things from UBI
@@ -25,13 +19,13 @@ RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/sha
 RUN bash -l -c "spack config add config:build_jobs:64"
 RUN bash -l -c "spack bootstrap now"
 
-ARG compiler_version
+ARG compiler_version=
 
 RUN bash -l -c "spack compiler find"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64 || true"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64"
 
-ARG mpi_version
+ARG mpi_version=
 
 RUN mkdir /home/runner/environment
 # Consider using here-documents once we get to Buildah 1.33.0+

--- a/dockerfiles/gnu-openmpi/Dockerfile
+++ b/dockerfiles/gnu-openmpi/Dockerfile
@@ -1,3 +1,9 @@
+# Default build argument values.
+# These must be redeclared after the FROM to allow for passed
+# build-args to override the default values.
+ARG compiler_version=
+ARG mpi_version=
+
 FROM registry.access.redhat.com/ubi8:latest
 
 # Disable all host repositories so that we're only using things from UBI
@@ -19,13 +25,13 @@ RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/sha
 RUN bash -l -c "spack config add config:build_jobs:64"
 RUN bash -l -c "spack bootstrap now"
 
-ARG compiler_version=
+ARG compiler_version
 
 RUN bash -l -c "spack compiler find"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64 || true"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64"
 
-ARG mpi_version=
+ARG mpi_version
 
 RUN mkdir /home/runner/environment
 # Consider using here-documents once we get to Buildah 1.33.0+
@@ -158,10 +164,10 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 CMD [ "/bin/bash" ]
 
 # Image basename (useful for describing image characteristics, e.g. toolchain)
-ARG AT2_image
+ARG AT2_image=
 ENV AT2_IMAGE=${AT2_image}
 # Image path as pushed (useful for referencing where to pull the image)
-ARG AT2_image_fullpath
+ARG AT2_image_fullpath=
 ENV AT2_IMAGE_FULLPATH=${AT2_image_fullpath}
 
 RUN bash -l -c "spack module tcl refresh -y %gcc${compiler_version}"
@@ -205,6 +211,15 @@ else\n\
   export CCACHE_DIR=$HOME/ccache-dir\n\
   mkdir -p \$CCACHE_DIR\n\
 fi">> /home/runner/.bashrc
+
+# Setup artifact Dockerfile in image
+RUN mkdir /home/runner/artifacts
+COPY Dockerfile /home/runner/artifacts/Dockerfile
+# Set artifact Dockerfile default arguments as the used build-arguments
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" /home/runner/artifacts/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc

--- a/dockerfiles/gnu-serial/Dockerfile
+++ b/dockerfiles/gnu-serial/Dockerfile
@@ -1,9 +1,5 @@
-# Default build argument values.
-# These must be redeclared after the FROM to allow for passed
-# build-args to override the default values.
-ARG compiler_version=
-
 FROM registry.access.redhat.com/ubi8:latest
+
 # Disable all host repositories so that we're only using things from UBI
 # (in the event that you're building a UBI container on a RHEL host, RedHat
 # tries to 'help' and let you use your subscription inside the container)
@@ -23,7 +19,7 @@ RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/sha
 RUN bash -l -c "spack config add config:build_jobs:64"
 RUN bash -l -c "spack bootstrap now"
 
-ARG compiler_version
+ARG compiler_version=
 
 RUN bash -l -c "spack compiler find"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64 || true"

--- a/dockerfiles/gnu-serial/Dockerfile
+++ b/dockerfiles/gnu-serial/Dockerfile
@@ -1,5 +1,9 @@
-FROM registry.access.redhat.com/ubi8:latest
+# Default build argument values.
+# These must be redeclared after the FROM to allow for passed
+# build-args to override the default values.
+ARG compiler_version=
 
+FROM registry.access.redhat.com/ubi8:latest
 # Disable all host repositories so that we're only using things from UBI
 # (in the event that you're building a UBI container on a RHEL host, RedHat
 # tries to 'help' and let you use your subscription inside the container)
@@ -19,7 +23,7 @@ RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/sha
 RUN bash -l -c "spack config add config:build_jobs:64"
 RUN bash -l -c "spack bootstrap now"
 
-ARG compiler_version=
+ARG compiler_version
 
 RUN bash -l -c "spack compiler find"
 RUN bash -l -c "spack -C /home/runner install gcc${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install gcc${compiler_version} target=x86_64 || true"
@@ -148,10 +152,10 @@ RUN rm /home/runner/Makefile
 CMD [ "/bin/bash" ]
 
 # Image basename (useful for describing image characteristics, e.g. toolchain)
-ARG AT2_image
+ARG AT2_image=
 ENV AT2_IMAGE=${AT2_image}
 # Image path as pushed (useful for referencing where to pull the image)
-ARG AT2_image_fullpath
+ARG AT2_image_fullpath=
 ENV AT2_IMAGE_FULLPATH=${AT2_image_fullpath}
 
 RUN bash -l -c "spack module tcl refresh -y %gcc${compiler_version}"
@@ -190,6 +194,14 @@ else\n\
   export CCACHE_DIR=$HOME/ccache-dir\n\
   mkdir -p \$CCACHE_DIR\n\
 fi">> /home/runner/.bashrc
+
+# Setup Dockerfile in built image
+RUN mkdir /home/runner/artifacts
+COPY Dockerfile /home/runner/artifacts/Dockerfile
+# Set Dockerfile default arguments as the used build-arguments
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" /home/runner/artifacts/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc

--- a/dockerfiles/python/Dockerfile
+++ b/dockerfiles/python/Dockerfile
@@ -127,16 +127,13 @@ RUN bash -l -c "cd /home/runner && make -j6 || true"
 RUN bash -l -c "cd /home/runner && make -j6"
 RUN rm /home/runner/Makefile
 
-# ENV OMPI_ALLOW_RUN_AS_ROOT=1
-# ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-
 CMD [ "/bin/bash" ]
 
 # Image basename (useful for describing image characteristics, e.g. toolchain)
-ARG AT2_image
+ARG AT2_image=
 ENV AT2_IMAGE=${AT2_image}
 # Image path as pushed (useful for referencing where to pull the image)
-ARG AT2_image_fullpath
+ARG AT2_image_fullpath=
 ENV AT2_IMAGE_FULLPATH=${AT2_image_fullpath}
 
 RUN bash -l -c "spack module tcl refresh -y"
@@ -148,6 +145,9 @@ module load emacs\n\
 module load py-pytest-cov\n\
 module load gh\n\
 ">> /home/runner/.bashrc
+
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc


### PR DESCRIPTION
Copy the Dockerfile inside the image it is built with and hardcode the build arguments inside the artifact Dockerfile with the values used when the image was built.

Tested building of the artifact Dockerfile and it was able to build without specifying any build arguments for the user.