### PR TITLE
Update Dockerfiles to use and expose an environment variable for artifact directory

### DIFF
--- a/dockerfiles/cuda-gnu-openmpi/Dockerfile
+++ b/dockerfiles/cuda-gnu-openmpi/Dockerfile
@@ -208,14 +208,15 @@ else\n\
 fi" >> /home/runner/.bashrc
 
 # Setup artifact Dockerfile in image
-RUN mkdir /home/runner/artifacts
-COPY Dockerfile /home/runner/artifacts/Dockerfile
+ENV AT2_ARTIFACTS_DIR=/home/runner/artifacts
+RUN mkdir $AT2_ARTIFACTS_DIR
+COPY Dockerfile ${AT2_ARTIFACTS_DIR}/Dockerfile
 # Set artifact Dockerfile default arguments as the used build-arguments
-RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
-RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
-RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" /home/runner/artifacts/Dockerfile
-RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" /home/runner/artifacts/Dockerfile
-RUN sed -i "s/^\(ARG cuda_version=\).*/\1${cuda_version}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG cuda_version=\).*/\1${cuda_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc

--- a/dockerfiles/gnu-openmpi/Dockerfile
+++ b/dockerfiles/gnu-openmpi/Dockerfile
@@ -207,13 +207,14 @@ else\n\
 fi">> /home/runner/.bashrc
 
 # Setup artifact Dockerfile in image
-RUN mkdir /home/runner/artifacts
-COPY Dockerfile /home/runner/artifacts/Dockerfile
+ENV AT2_ARTIFACTS_DIR=/home/runner/artifacts
+RUN mkdir $AT2_ARTIFACTS_DIR
+COPY Dockerfile ${AT2_ARTIFACTS_DIR}/Dockerfile
 # Set artifact Dockerfile default arguments as the used build-arguments
-RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
-RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
-RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" /home/runner/artifacts/Dockerfile
-RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" /home/runner/artifacts/Dockerfile
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc

--- a/dockerfiles/gnu-serial/Dockerfile
+++ b/dockerfiles/gnu-serial/Dockerfile
@@ -191,13 +191,14 @@ else\n\
   mkdir -p \$CCACHE_DIR\n\
 fi">> /home/runner/.bashrc
 
-# Setup Dockerfile in built image
-RUN mkdir /home/runner/artifacts
-COPY Dockerfile /home/runner/artifacts/Dockerfile
-# Set Dockerfile default arguments as the used build-arguments
-RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
-RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
-RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" /home/runner/artifacts/Dockerfile
+# Setup artifact Dockerfile in image
+ENV AT2_ARTIFACTS_DIR=/home/runner/artifacts
+RUN mkdir $AT2_ARTIFACTS_DIR
+COPY Dockerfile ${AT2_ARTIFACTS_DIR}/Dockerfile
+# Set artifact Dockerfile default arguments as the used build-arguments
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc

--- a/dockerfiles/python/Dockerfile
+++ b/dockerfiles/python/Dockerfile
@@ -146,8 +146,13 @@ module load py-pytest-cov\n\
 module load gh\n\
 ">> /home/runner/.bashrc
 
-RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" /home/runner/artifacts/Dockerfile
-RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" /home/runner/artifacts/Dockerfile
+# Setup artifact Dockerfile in image
+ENV AT2_ARTIFACTS_DIR=/home/runner/artifacts
+RUN mkdir $AT2_ARTIFACTS_DIR
+COPY Dockerfile ${AT2_ARTIFACTS_DIR}/Dockerfile
+# Set artifact Dockerfile default arguments as the used build-arguments
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" ${AT2_ARTIFACTS_DIR}/Dockerfile
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc


### PR DESCRIPTION
Use and expose an environment variable for the artifacts directory path. This environment variable can later be referenced by clients for the set of produced artifacts.