### PR TITLE
Switch to netlib-lapack for CUDA containers

### DIFF
--- a/dockerfiles/cuda-gnu-openmpi/Dockerfile
+++ b/dockerfiles/cuda-gnu-openmpi/Dockerfile
@@ -68,7 +68,7 @@ spack:\n\
     - py-mpi4py\n\
     - py-numpy\n\
     - py-pybind11\n\
-    - openblas\n\
+    - netlib-lapack\n\
     - emacs\n\
     - gh\n\
   concretizer:\n\
@@ -190,7 +190,7 @@ module load binder\n\
 module load py-mpi4py\n\
 module load py-numpy\n\
 module load py-pybind11\n\
-module load openblas\n\
+module load netlib-lapack\n\
 module load emacs\n\
 module load gh\n\
 \n\


### PR DESCRIPTION
Complex + OpenBLAS does not appear to work.  Since we currently build the CUDA configurations with complex enabled, this causes test failures in Stokhos and PanzerMiniEM.  So switch to netlib-lapack for the time being.

This also gives us better BLAS coverage across multiple providers.