### PR TITLE
Fix list warning

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -69,7 +69,7 @@ def list_container_images(gitlab_url="https://gitlab-ex.sandia.gov", project_id=
     gl = gitlab.Gitlab(gitlab_url)
     project = gl.projects.get(project_id)
     repos = project.repositories.list()
-    image_list = [tag.location for repo in repos for tag in repo.tags.list()]
+    image_list = [tag.location for repo in repos for tag in repo.tags.list(iterator=True)]
 
     return image_list
 


### PR DESCRIPTION
Jenkins gave the following warning:

deploy.py:72: UserWarning: Calling a `list()` method without specifying `get_all=True` or `iterator=True` will return a maximum of 20 items. Your query returned 20 of 457 items. See  https://python-gitlab.readthedocs.io/en/v5.3.1/api-usage.html#pagination for more details. If this was done intentionally, then this warning can be supressed by adding the argument `get_all=False` to the `list()` call.
