### PR TITLE
Add clang-openmpi container recipe

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -52,6 +52,12 @@ DEPLOYS = [
         "build_args": {},
         "production": True,
     },
+    {
+        "image_name": "ubi9-clang-19.1.6-openmpi-4.1.6",
+        "dockerfile": "clang-openmpi",
+        "build_args": {"compiler_version": "@19.1.6", "mpi_version": "@4.1.6"},
+        "production": True,
+    },
 ]
 
 

--- a/dockerfiles/clang-openmpi/.gitignore
+++ b/dockerfiles/clang-openmpi/.gitignore
@@ -1,0 +1,1 @@
+/clang-19.1.6-openmpi-4.1.6-trilinos-env.output

--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -1,0 +1,201 @@
+FROM registry.access.redhat.com/ubi9:latest
+
+# Disable all host repositories so that we're only using things from UBI
+# (in the event that you're building a UBI container on a RHEL host, RedHat
+# tries to 'help' and let you use your subscription inside the container)
+RUN rm -rf /etc/rhsm-host
+RUN yum -y --setopt=tsflags=nodocs update && yum clean all
+
+RUN yum -y install gcc gcc-c++ gcc-gfortran xz bzip2 patch diffutils file make git python procps environment-modules gettext unzip libX11-devel
+
+RUN useradd runner
+USER runner
+
+RUN git clone https://github.com/spack/spack.git /home/runner/spack && cd /home/runner/spack && git checkout develop-2025-01-12
+RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/share/spack/setup-env.sh\n" >> /home/runner/.bashrc
+RUN bash -l -c "spack config add config:build_jobs:64"
+RUN bash -l -c "spack mirror add --unsigned --type=binary gitlab-ex oci://registry-ex.sandia.gov/trilinos-project/trilinos-containers/buildcache"
+RUN bash -l -c "spack bootstrap now"
+
+ARG compiler_version=
+
+RUN bash -l -c "spack compiler find"
+RUN bash -l -c "spack -C /home/runner install llvm+clang+lld${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install llvm+clang+lld${compiler_version} target=x86_64 || true"
+RUN bash -l -c "spack -C /home/runner install llvm+clang+lld${compiler_version} target=x86_64 > /dev/null & spack -C /home/runner install llvm+clang+lld${compiler_version} target=x86_64"
+
+ARG mpi_version=
+
+RUN mkdir /home/runner/environment
+# Consider using here-documents once we get to Buildah 1.33.0+
+# https://github.com/containers/buildah/issues/3474#issuecomment-1821752538
+RUN echo -e "\
+spack:\n\
+  include:\n\
+  - modules.yaml\n\
+  packages:\n\
+    all:\n\
+      require:\n\
+      - '%clang'\n\
+      target: [x86_64]\n\
+  specs:\n\
+  - cmake\n\
+  - ninja\n\
+  - boost +program_options+system\n\
+  - cgns\n\
+  - hdf5 +hl\n\
+  - metis\n\
+  - netcdf-c +parallel-netcdf\n\
+  - parallel-netcdf\n\
+  - parmetis\n\
+  - superlu-dist\n\
+  - superlu@5\n\
+  - zlib\n\
+  - openmpi${mpi_version}\n\
+  - matio\n\
+  - openblas\n\
+  - fmt\n\
+  concretizer:\n\
+    unify: when_possible\n\
+  view: false\n" > /home/runner/environment/spack.yaml
+
+RUN echo -e "\
+modules:\n\
+  prefix_inspections:\n\
+    ./bin:\n\
+      - PATH\n\
+    ./lib:\n\
+    - LIBRARY_PATH\n\
+    - LD_LIBRARY_PATH\n\
+    ./lib64:\n\
+    - LIBRARY_PATH\n\
+    - LD_LIBRARY_PATH\n\
+    ./include:\n\
+    - INCLUDE\n\
+    ./man:\n\
+      - MANPATH\n\
+    ./share/man:\n\
+      - MANPATH\n\
+    ./share/aclocal:\n\
+      - ACLOCAL_PATH\n\
+    ./lib/pkgconfig:\n\
+      - PKG_CONFIG_PATH\n\
+    ./lib64/pkgconfig:\n\
+      - PKG_CONFIG_PATH\n\
+    ./share/pkgconfig:\n\
+      - PKG_CONFIG_PATH\n\
+    ./:\n\
+      - CMAKE_PREFIX_PATH\n\
+  default:\n\
+    enable:\n\
+      - tcl\n\
+    tcl:\n\
+      hash_length: 0\n\
+      projections:\n\
+        all: '{name}/{version}'\n\
+      all:\n\
+        conflict:\n\
+        - '{name}'\n\
+        environment:\n\
+          set:\n\
+            '{name}_ROOT': '{prefix}'\n\
+            '{name}_VERSION': '{version}'\n\
+            '{name}_BIN': '{prefix.bin}'\n\
+            '{name}_INC': '{prefix.include}'\n\
+            '{name}_LIB': '{prefix.lib}'\n\
+        autoload: none\n\
+      blas:\n\
+        environment:\n\
+          set:\n\
+            'BLAS_ROOT': '{prefix}'\n\
+            'LAPACK_ROOT': '{prefix}'\n\
+      gcc:\n\
+        environment:\n\
+          set:\n\
+            'COMPILER_ROOT': '{prefix}'\n\
+      llvm:\n\
+        environment:\n\
+          set:\n\
+            'COMPILER_ROOT': '{prefix}'" >> /home/runner/environment/modules.yaml
+
+RUN bash -l -c "spack module tcl refresh -y"
+
+RUN echo -e "spack env activate /home/runner/environment\n" >> /home/runner/.bashrc
+RUN bash -l -c "echo \"export MODULEPATH=/home/runner/spack/share/spack/modules/linux-\\\$(spack arch --operating-system)-x86_64\" >> /home/runner/.bashrc"
+RUN bash -l -c "module load llvm && FC=\$(type -p gfortran) spack compiler find --mixed-toolchain $COMPILER_ROOT"
+
+RUN bash -l -c "spack external find python"
+
+RUN bash -l -c "spack concretize"
+RUN bash -l -c "cd /home/runner && spack env depfile -o Makefile"
+# Just in case a mirror fails to pull, retry the spack install so that we can preserve
+# all of the packages that did build successfully
+RUN bash -l -c "cd /home/runner && make -j6 || true"
+RUN bash -l -c "cd /home/runner && make -j6"
+RUN rm /home/runner/Makefile
+
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
+CMD [ "/bin/bash" ]
+
+# Image basename (useful for describing image characteristics, e.g. toolchain)
+ARG AT2_image=
+ENV AT2_IMAGE=${AT2_image}
+# Image path as pushed (useful for referencing where to pull the image)
+ARG AT2_image_fullpath=
+ENV AT2_IMAGE_FULLPATH=${AT2_image_fullpath}
+
+RUN bash -l -c "spack module tcl refresh -y %llvm+clang+lld${compiler_version}"
+RUN echo -e "\
+module load ccache\n\
+module load valgrind\n\
+module load gdb\n\
+module load llvm\n\
+module load openmpi\n\
+module load cmake\n\
+module load ninja\n\
+module load boost\n\
+module load cgns\n\
+module load hdf5\n\
+module load metis\n\
+module load netcdf-c\n\
+module load parallel-netcdf\n\
+module load parmetis\n\
+module load superlu\n\
+module load superlu-dist\n\
+module load zlib\n\
+module load matio\n\
+module load python\n\
+module load binder\n\
+module load py-mpi4py\n\
+module load py-numpy\n\
+module load py-pybind11\n\
+module load openblas\n\
+module load emacs\n\
+module load gh\n\
+\n\
+export CCACHE_NODISABLE=true\n\
+export CCACHE_BASEDIR=$HOME\n\
+export CCACHE_NOHARDLINK=true\n\
+export CCACHE_UMASK=077\n\
+export CCACHE_MAXSIZE=100G\n\
+\n\
+if [ -d /ccache-dir ]; then\n\
+  export CCACHE_DIR=/ccache-dir\n\
+else\n\
+  export CCACHE_DIR=$HOME/ccache-dir\n\
+  mkdir -p \$CCACHE_DIR\n\
+fi">> /home/runner/.bashrc
+
+# Setup artifact Dockerfile in image
+ENV AT2_ARTIFACTS_DIR=/home/runner/artifacts
+RUN mkdir $AT2_ARTIFACTS_DIR
+COPY Dockerfile ${AT2_ARTIFACTS_DIR}/Dockerfile
+# Set artifact Dockerfile default arguments as the used build-arguments
+RUN sed -i "s/^\(ARG AT2_image=\).*/\1${AT2_image}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s|^\(ARG AT2_image_fullpath=\).*|\1${AT2_image_fullpath}|" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG compiler_version=\).*/\1${compiler_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" ${AT2_ARTIFACTS_DIR}/Dockerfile
+
+USER root
+RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc

--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -47,7 +47,7 @@ spack:\n\
   - netcdf-c +parallel-netcdf\n\
   - parallel-netcdf\n\
   - parmetis\n\
-  - superlu-dist\n\
+  - superlu-dist@5.4.0\n\
   - superlu@5\n\
   - zlib\n\
   - openmpi${mpi_version}\n\

--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -6,7 +6,7 @@ FROM registry.access.redhat.com/ubi9:latest
 RUN rm -rf /etc/rhsm-host
 RUN yum -y --setopt=tsflags=nodocs update && yum clean all
 
-RUN yum -y install gcc gcc-c++ gcc-gfortran xz bzip2 patch diffutils file make git python procps environment-modules gettext unzip libX11-devel
+RUN yum -y install gcc gcc-c++ gcc-gfortran xz bzip2 patch diffutils file make git python python3-pip procps environment-modules gettext unzip libX11-devel
 
 RUN useradd runner
 USER runner
@@ -38,6 +38,8 @@ spack:\n\
       - '%clang${compiler_version}'\n\
       target: [x86_64]\n\
   specs:\n\
+  - ccache\n\
+  - valgrind\n\
   - cmake\n\
   - ninja\n\
   - boost +program_options+system\n\
@@ -54,6 +56,8 @@ spack:\n\
   - matio\n\
   - openblas\n\
   - fmt\n\
+  - emacs\n\
+  - gh\n\
   concretizer:\n\
     unify: when_possible\n\
   view: false\n" > /home/runner/environment/spack.yaml
@@ -150,7 +154,6 @@ RUN bash -l -c "spack module tcl refresh -y %llvm+clang+lld${compiler_version}"
 RUN echo -e "\
 module load ccache\n\
 module load valgrind\n\
-module load gdb\n\
 module load llvm\n\
 module load openmpi\n\
 module load cmake\n\
@@ -166,11 +169,6 @@ module load superlu\n\
 module load superlu-dist\n\
 module load zlib\n\
 module load matio\n\
-module load python\n\
-module load binder\n\
-module load py-mpi4py\n\
-module load py-numpy\n\
-module load py-pybind11\n\
 module load openblas\n\
 module load emacs\n\
 module load gh\n\

--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -121,7 +121,8 @@ RUN bash -l -c "spack module tcl refresh -y"
 
 RUN echo -e "spack env activate /home/runner/environment\n" >> /home/runner/.bashrc
 RUN bash -l -c "echo \"export MODULEPATH=/home/runner/spack/share/spack/modules/linux-\\\$(spack arch --operating-system)-x86_64\" >> /home/runner/.bashrc"
-RUN bash -l -c "module load llvm && FC=\$(type -p gfortran) spack compiler find --mixed-toolchain $COMPILER_ROOT"
+RUN bash -l -c "export FC=\$(type -p gfortran) >> /home/runner/.bashrc"
+RUN bash -l -c "module load llvm && spack compiler find --mixed-toolchain $COMPILER_ROOT"
 
 RUN bash -l -c "spack external find python"
 

--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -14,7 +14,7 @@ USER runner
 RUN git clone https://github.com/spack/spack.git /home/runner/spack && cd /home/runner/spack && git checkout develop-2025-01-12
 RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/share/spack/setup-env.sh\n" >> /home/runner/.bashrc
 RUN bash -l -c "spack config add config:build_jobs:64"
-RUN bash -l -c "spack mirror add --unsigned --type=binary gitlab-ex oci://registry-ex.sandia.gov/trilinos-project/trilinos-containers/buildcache"
+#RUN bash -l -c "spack mirror add --unsigned --type=binary gitlab-ex oci://registry-ex.sandia.gov/trilinos-project/trilinos-containers/buildcache"
 RUN bash -l -c "spack bootstrap now"
 
 ARG compiler_version=
@@ -35,7 +35,7 @@ spack:\n\
   packages:\n\
     all:\n\
       require:\n\
-      - '%clang'\n\
+      - '%clang${compiler_version}'\n\
       target: [x86_64]\n\
   specs:\n\
   - cmake\n\

--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -6,7 +6,7 @@ FROM registry.access.redhat.com/ubi9:latest
 RUN rm -rf /etc/rhsm-host
 RUN yum -y --setopt=tsflags=nodocs update && yum clean all
 
-RUN yum -y install gcc gcc-c++ gcc-gfortran xz bzip2 patch diffutils file make git python python3-pip procps environment-modules gettext unzip libX11-devel
+RUN yum -y install gcc gcc-c++ gcc-gfortran xz bzip2 patch diffutils file make git python python3-pip perl-File-Copy perl-File-Compare perl-Sys-Hostname procps environment-modules gettext unzip libX11-devel
 
 RUN useradd runner
 USER runner

--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -14,7 +14,6 @@ USER runner
 RUN git clone https://github.com/spack/spack.git /home/runner/spack && cd /home/runner/spack && git checkout develop-2025-01-12
 RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/share/spack/setup-env.sh\n" >> /home/runner/.bashrc
 RUN bash -l -c "spack config add config:build_jobs:64"
-#RUN bash -l -c "spack mirror add --unsigned --type=binary gitlab-ex oci://registry-ex.sandia.gov/trilinos-project/trilinos-containers/buildcache"
 RUN bash -l -c "spack bootstrap now"
 
 ARG compiler_version=

--- a/dockerfiles/clang-openmpi/build-clang-openmpi-image.sh
+++ b/dockerfiles/clang-openmpi/build-clang-openmpi-image.sh
@@ -1,0 +1,10 @@
+#/bin/bash
+export CLANG_VERSION=19.1.6
+export OPENMPI_VERSION=4.1.6
+
+nohup podman build \
+        --build-arg=compiler_version="@${CLANG_VERSION}" \
+        --build-arg=mpi_version="@${OPENMPI_VERSION}" \
+        -t clang-${CLANG_VERSION}-openmpi-${OPENMPI_VERSION}-trilinos-env:${USER}-test . \
+  &> clang-${CLANG_VERSION}-openmpi-${OPENMPI_VERSION}-trilinos-env.output &
+

--- a/dockerfiles/clang-openmpi/build-clang-openmpi-image.sh
+++ b/dockerfiles/clang-openmpi/build-clang-openmpi-image.sh
@@ -2,7 +2,16 @@
 export CLANG_VERSION=19.1.6
 export OPENMPI_VERSION=4.1.6
 
-nohup podman build \
+DOCKER_EXEC=$(which podman 2> /dev/null)
+if [[ "${DOCKER_EXEC}" == "" ]]; then
+  DOCKER_EXEC=$(which docker 2> /dev/null)
+fi
+if [[ "${DOCKER_EXEC}" == "" ]]; then
+  echo "No podman or docker found in PATH. Please install one of them."
+  exit 1
+fi
+
+nohup ${DOCKER_EXEC} build \
         --build-arg=compiler_version="@${CLANG_VERSION}" \
         --build-arg=mpi_version="@${OPENMPI_VERSION}" \
         -t clang-${CLANG_VERSION}-openmpi-${OPENMPI_VERSION}-trilinos-env:${USER}-test . \


### PR DESCRIPTION
- Add a clang-openmpi container recipe containing the necessary TPL stack to build Trilinos.
- Add a clang@19.1.6-openmpi@4.1.6 image deployment configuration
