### PR TITLE
Remove Intel classic spec

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -44,11 +44,6 @@ DEPLOYS = [
         "production": True,
     },
     {
-        "image_name": "ubi8-intel-intelmpi",
-        "dockerfile": "intel-intelmpi",
-        "build_args": {},
-        "production": True,
-    },
         "image_name": "ubi8-oneapi-2024.1.0",
         "dockerfile": "oneapi",
         "build_args": {"compiler_version": "@2024.1.0"},


### PR DESCRIPTION
It isn't necessary anymore, it wastes build time, and it contained a typo (which has been causing our nightly builds to fail).