### PR TITLE
Change permissions to avoid doubling image size

### DIFF
--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -11,6 +11,14 @@ RUN yum -y install gcc gcc-c++ gcc-gfortran xz bzip2 patch diffutils file make g
 RUN useradd runner
 USER runner
 
+# Open up /home/runner so other regular users can do anything, just like root can
+RUN printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'umask 000' \
+  'exec /bin/bash -o pipefail -c "$*"' \
+  > /tmp/run-with-umask && chmod a+x /tmp/run-with-umask
+SHELL ["/tmp/run-with-umask"]
+
 RUN git clone https://github.com/spack/spack.git /home/runner/spack && cd /home/runner/spack && git checkout bd519af8bc62a6f9eea6f4c0fa0bf498a0cc0dfb
 RUN echo -e "export SPACK_ROOT=/home/runner/spack\nsource /home/runner/spack/share/spack/setup-env.sh\n" >> /home/runner/.bashrc
 RUN bash -l -c "spack config add config:build_jobs:64"
@@ -197,3 +205,6 @@ RUN sed -i "s/^\(ARG mpi_version=\).*/\1${mpi_version}/" ${AT2_ARTIFACTS_DIR}/Do
 
 USER root
 RUN echo -e "source /home/runner/.bashrc" >> /root/.bashrc
+
+# Must open the base directory to allow writing into it at the very end
+RUN chmod a+rwX /home/runner


### PR DESCRIPTION
@achauphan, @sebrowne 

## Desccription

This approach creates files under /home/runner/ to all so that we don't need to change permissions at the end and double the size of the Docker image!

And this also reduces the size of the image created by more than 2x. Apparently, the Dockerfile before this was changing the permissions for large numbers of files between layers and was more than doubling the size of the generated image.
