### PR TITLE
Add googletest package to Dockerfiles

### DIFF
--- a/dockerfiles/clang-openmpi/Dockerfile
+++ b/dockerfiles/clang-openmpi/Dockerfile
@@ -57,6 +57,7 @@ spack:\n\
   - fmt\n\
   - emacs\n\
   - gh\n\
+  - googletest\n\
   concretizer:\n\
     unify: when_possible\n\
   view: false\n" > /home/runner/environment/spack.yaml
@@ -171,6 +172,7 @@ module load matio\n\
 module load openblas\n\
 module load emacs\n\
 module load gh\n\
+module load googletest\n\
 \n\
 export CCACHE_NODISABLE=true\n\
 export CCACHE_BASEDIR=$HOME\n\

--- a/dockerfiles/cuda-gnu-openmpi/Dockerfile
+++ b/dockerfiles/cuda-gnu-openmpi/Dockerfile
@@ -63,6 +63,7 @@ spack:\n\
     - py-numpy\n\
     - py-pybind11\n\
     - netlib-lapack\n\
+    - googletest\n\
   concretizer:\n\
     unify: when_possible\n\
   specs:\n\
@@ -193,6 +194,7 @@ module load py-pybind11\n\
 module load netlib-lapack\n\
 module load emacs\n\
 module load gh\n\
+module load googletest\n\
 \n\
 export CCACHE_NODISABLE=true\n\
 export CCACHE_BASEDIR=$HOME\n\

--- a/dockerfiles/gnu-openmpi/Dockerfile
+++ b/dockerfiles/gnu-openmpi/Dockerfile
@@ -71,6 +71,7 @@ spack:\n\
   - ninja\n\
   - emacs\n\
   - gh\n\
+  - googletest\n\
   view: false\n\
   packages:\n\
     all:\n\
@@ -192,6 +193,7 @@ module load py-pybind11\n\
 module load netlib-lapack\n\
 module load emacs\n\
 module load gh\n\
+module load googletest\n\
 \n\
 export CCACHE_NODISABLE=true\n\
 export CCACHE_BASEDIR=$HOME\n\

--- a/dockerfiles/gnu-serial/Dockerfile
+++ b/dockerfiles/gnu-serial/Dockerfile
@@ -51,6 +51,7 @@ spack:\n\
     - openblas\n\
     - fmt\n\
     - unzip\n\
+    - googletest\n\
   concretizer:\n\
     unify: when_possible\n\
   specs:\n\
@@ -177,6 +178,7 @@ module load py-pybind11\n\
 module load openblas\n\
 module load emacs\n\
 module load gh\n\
+module load googletest\n\
 \n\
 export CCACHE_NODISABLE=true\n\
 export CCACHE_BASEDIR=$HOME\n\

--- a/dockerfiles/gnu-ubi10/Dockerfile
+++ b/dockerfiles/gnu-ubi10/Dockerfile
@@ -47,6 +47,7 @@ spack:\n\
     - py-pybind11\n\
     - openblas\n\
     - fmt\n\
+    - googletest\n\
   concretizer:\n\
     unify: when_possible\n\
   specs:\n\
@@ -174,6 +175,7 @@ module load py-pybind11\n\
 module load openblas\n\
 module load emacs\n\
 module load gh\n\
+module load googletest\n\
 \n\
 export CCACHE_NODISABLE=true\n\
 export CCACHE_BASEDIR=$HOME\n\

--- a/dockerfiles/oneapi/Dockerfile
+++ b/dockerfiles/oneapi/Dockerfile
@@ -50,6 +50,7 @@ spack:\n\
     - intel-oneapi-mkl\n\
     - fmt\n\
     - unzip\n\
+    - googletest\n\
   concretizer:\n\
     unify: when_possible\n\
   specs:\n\
@@ -179,6 +180,7 @@ module load matio\n\
 module load intel-oneapi-mkl\n\
 module load emacs\n\
 module load gh\n\
+module load googletest\n\
 \n\
 export CCACHE_NODISABLE=true\n\
 export CCACHE_BASEDIR=$HOME\n\


### PR DESCRIPTION
## Motivation
[Trilinos PR#14719 ](https://github.com/trilinos/Trilinos/pull/14719) removes Gtest as an internal Trilinos package and instead requiring users to have a local install ready to be used, similar how we handle other TPLs.

This PR aims to add Gtest to our container environments so that users hoping to have an all-in-one solution with our containers won't have to manually install gtest.

## Testing
Before this PR can be merged:
- [x] Build & test Trilinos with an image with `gtest` with an updated version of Trilinos that removes the internal `gtest` package.